### PR TITLE
Handles CTRL+D presses and refactor for betty style

### DIFF
--- a/execute_command.c
+++ b/execute_command.c
@@ -1,21 +1,24 @@
 #include "header.h"
 
-extern char **environ;
 /**
  * execute_command - execute a command
  *@pathname: path of command to execute
  *@arg_array: arguments to pass to command
+ *@line: command line to free if exit is called
  */
 
-void execute_command(char *pathname, char **arg_array)
+void execute_command(char *pathname, char **arg_array, char *line)
 {
 	int status, i;
-	char *error[] = {"/bin/echo" , "-n", "Error\n", NULL};
+	char *error[] = {"/bin/echo", "-n", "Error\n", NULL};
 	char *env = *environ;
 
 	/* check for exit command */
 	if (strcmp(arg_array[0], "exit") == 0)
 	{
+		free(pathname);
+		free(arg_array);
+		free(line);
 		exit(0);
 	}
 
@@ -32,8 +35,8 @@ void execute_command(char *pathname, char **arg_array)
 
 	if (fork() == 0)
 	{
-		/* execute command @ pathname w/ arguments in arg_array *
-		 * or print an error on failure                         */
+		/* execute command @ pathname w/ arguments in arg_array */
+		/* or print an error on failure */
 		if ((execve(pathname, arg_array, NULL)) == -1)
 		{
 			/* will print "error" using echo to close pid */
@@ -41,9 +44,5 @@ void execute_command(char *pathname, char **arg_array)
 		}
 	}
 	else
-	{
 		wait(&status);
-	}
-
-	return;
 }

--- a/header.h
+++ b/header.h
@@ -9,9 +9,11 @@
 #include <sys/wait.h>
 #include <signal.h>
 
+extern char **environ;
+
 void remove_new_line(char *str);
 char **seperate_line(char *line);
 char *find_command_path(char *command);
-void execute_command(char *pathname, char **arg_array);
+void execute_command(char *pathname, char **arg_array, char *line);
 
 #endif

--- a/main.c
+++ b/main.c
@@ -1,37 +1,51 @@
 #include "header.h"
 
+/**
+ * main - entry point for custom shell
+ *
+ * Return: 0
+ */
+
 int main(void)
 {
 	char *line = NULL;
 	size_t len = 0;
-	ssize_t read;
-	char **argv;
-	char *path;
+	ssize_t rd;
+	char **argv = NULL;
+	char *path = NULL;
 
 	/* wait for input */
 	printf("$ ");
+	/* Ignore signals */
 	signal(SIGINT, SIG_IGN);
 
-	while ((read = getline(&line, &len, stdin)) != -1)
+	while (1)
 	{
+		rd = getline(&line, &len, stdin);
+		/* handles Ctrl+D presses */
+		if (rd == -1)
+			continue;
 		/* remove nl */
 		remove_new_line(line);
-
-		if (line != NULL && read > 1)
+		/* verify a command is present */
+		if (line != NULL && rd > 1)
 		{
 			/* seperate line into command and arguments */
 			argv = seperate_line(line);
 			/* find command assume base path of /bin/*/
 			path = find_command_path(argv[0]);
 			/* execute command */
-			execute_command(path, argv);
-			/* reset pathname */
-			free(path);
-			free(argv);
+			execute_command(path, argv, line);
 		}
+		/* reset pathname */
+		if (path != NULL)
+			free(path);
+		if (argv != NULL)
+			free(argv);
 		/* Back to start */
 		printf("$ ");
 	}
-
 	free(line);
+
+	return (0);
 }


### PR DESCRIPTION
CTRL+D no longer exits the shell program. The exit command needs to be used.
Made adjustments to conform to Betty style.
Added free statements before exiting to reduce memory leaks.
In main.c, renamed variable read to rd to avoid conflicts with the function read().